### PR TITLE
ci: fix rwasm publish workflow dependency order

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,12 +44,12 @@ jobs:
         run: |
           tag="${{ steps.extract_version.outputs.version }}"
           tag="${tag#v}"
-          
+
           cargo_ver=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "wasmtime-cli") | .version')
-          
+
           echo "tag=$tag"
           echo "cargo_ver=$cargo_ver"
-          
+
           [[ "$tag" == "$cargo_ver"* ]] || {
             echo "Tag $tag doesn't match the Cargo version $cargo_ver"
             exit 1
@@ -57,17 +57,41 @@ jobs:
 
       - name: Verify package
         run: |
+          # For fresh release chains, dry-run for dependent crates fails until
+          # prerequisite crates are actually published and indexed.
           cargo publish --dry-run -p wasmtime-environ-rwasm
-          cargo publish --dry-run -p wasmtime-internal-cranelift-rwasm
-          cargo publish --dry-run -p wasmtime-rwasm
+          cargo check -p wasmtime-internal-cranelift-rwasm -p wasmtime-rwasm
 
       - name: Publish to crates.io
         if: ${{ github.event_name != 'workflow_dispatch' || !inputs.dry_run }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
+          set -euo pipefail
+
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "wasmtime-rwasm") | .version')
+
+          wait_for_index() {
+            crate="$1"
+            version="$2"
+            echo "Waiting for ${crate} ${version} in crates.io index..."
+            for _ in $(seq 1 30); do
+              if cargo search "$crate" | grep -q "^${crate} = \"${version}\""; then
+                echo "Found ${crate} ${version}"
+                return 0
+              fi
+              sleep 10
+            done
+            echo "Timed out waiting for ${crate} ${version}"
+            return 1
+          }
+
           cargo publish -p wasmtime-environ-rwasm
-          cargo search wasmtime-environ-rwasm | head
+          wait_for_index wasmtime-environ-rwasm "$VERSION"
+
+          cargo publish --dry-run -p wasmtime-internal-cranelift-rwasm
           cargo publish -p wasmtime-internal-cranelift-rwasm
-          cargo search wasmtime-internal-cranelift-rwasm | head
+          wait_for_index wasmtime-internal-cranelift-rwasm "$VERSION"
+
+          cargo publish --dry-run -p wasmtime-rwasm
           cargo publish -p wasmtime-rwasm


### PR DESCRIPTION
## Summary
Fix crates.io release workflow for the rwasm crate chain so fresh releases don't fail verification.

## Problem
Current workflow runs:
- `cargo publish --dry-run -p wasmtime-environ-rwasm`
- `cargo publish --dry-run -p wasmtime-internal-cranelift-rwasm`
- `cargo publish --dry-run -p wasmtime-rwasm`

For a fresh version, dry-run on dependent crates fails because prerequisite crates are not yet indexed on crates.io.

## Changes
- In verify step:
  - keep dry-run for the first crate only (`wasmtime-environ-rwasm`)
  - replace dependent dry-runs with `cargo check -p wasmtime-internal-cranelift-rwasm -p wasmtime-rwasm`
- In publish step:
  - publish in strict dependency order
  - wait for crates.io index propagation between publishes (`cargo search` + retry loop)
  - run dependent dry-runs only after prerequisites are published/indexed

## Result
Tag-driven publish flow is now deterministic for new versions:
1. `wasmtime-environ-rwasm`
2. `wasmtime-internal-cranelift-rwasm`
3. `wasmtime-rwasm`
